### PR TITLE
Removes object-orientation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,657 +7,658 @@ import urllib2
 import tarfile
 import re
 import numpy
-import setuptools
-from distutils.command.build_py import build_py
+from setuptools import setup, find_packages, Extension
 
 """
 This file builds and installs the NuPIC binaries.
 """
 
-nupicCoreBucketURL = \
+NUPIC_CORE_BUCKET = \
   "https://s3-us-west-2.amazonaws.com/artifacts.numenta.org/numenta/nupic.core"
+REPO_DIR = os.path.dirname(os.path.realpath(__file__))
+UNIX_PLATFORMS = ["linux", "darwin"]
+WINDOWS_PLATFORMS = ["win"]
 
 
 
-class Setup:
+def downloadFile(url, destFile, silent=False):
+  """
+  Download a file to the specified location
+  """
+
+  if not silent:
+    print "Downloading from\n\t%s\nto\t%s.\n" % (url, destFile)
+
+  destDir = os.path.dirname(destFile)
+  if not os.path.exists(destDir):
+    os.makedirs(destDir)
+
+  try:
+    response = urllib2.urlopen(url)
+  except urllib2.URLError:
+    return False
+
+  file = open(destFile, "wb")
+
+  totalSize = response.info().getheader('Content-Length').strip()
+  totalSize = int(totalSize)
+  bytesSoFar = 0
+
+  # Download chunks writing them to target file
+  chunkSize = 8192
+  oldPercent = 0
+  while True:
+    chunk = response.read(chunkSize)
+    bytesSoFar += len(chunk)
+
+    if not chunk:
+      break
+
+    file.write(chunk)
+
+    # Show progress
+    if not silent:
+      percent = (float(bytesSoFar) / totalSize) * 100
+      percent = int(percent)
+      if percent != oldPercent and percent % 5 == 0:
+        print ("Downloaded %i of %i bytes (%i%%)."
+               % (bytesSoFar, totalSize, int(percent)))
+        oldPercent = percent
+
+  file.close()
+
+  return True
 
 
 
-  def __init__(self):
-    self.repositoryDir = os.getcwd()
-    self.options = self.getCommandLineOptions()
-    self.platform, self.bitness = self.getPlatformInfo()
+def unpackFile(package, dirToUnpack, destDir, silent=False):
+  """
+  Unpack package file to the specified directory
+  """
+
+  if not silent:
+    print "Unpacking %s into %s..." % (package, destDir)
+
+  file = tarfile.open(package, 'r:gz')
+  file.extractall(destDir)
+  file.close()
+
+  # Copy subdirectories to a level up
+  subDirs = os.listdir(destDir + "/" + dirToUnpack)
+  for dir in subDirs:
+    shutil.rmtree(destDir + "/" + dir, True)
+    shutil.move(destDir + "/" + dirToUnpack + "/" + dir, destDir + "/" + dir)
+  shutil.rmtree(destDir + "/" + dirToUnpack, True)
 
 
 
-  def getCommandLineOptions(self):
+def printOptions(optionsDesc):
+  """
+  Print command line options.
+  """
 
-    # optionDesc = [name, value, description]
-    optionsDesc = []
-    optionsDesc.append(
-      ["nupic-core-dir",
-       "dir",
-       "(optional) Absolute path to nupic.core binary release directory"]
-    )
-    optionsDesc.append(
-      ["skip-compare-versions",
-       "",
-       "(optional) Skip nupic.core version comparison"]
-    )
-    optionsDesc.append(
-      ["user-make-command",
-       "file",
-       "(optional) Default `make` command used to build nupic.core"]
-    )
-
-    # Read command line options looking for extra options
-    # For example, an user could type:
-    #   python setup.py install --user-make-command="usr/bin/make"
-    # which will set the Make executable
-    optionsValues = dict()
-    for arg in sys.argv[:]:
-      optionFound = False
-      for option in optionsDesc:
-        name = option[0]
-        if "--" + name in arg:
-          value = None
-          hasValue = (option[1] != "")
-          if hasValue:
-            (_, _, value) = arg.partition("=")
-
-          optionsValues[name] = value
-          sys.argv.remove(arg)
-          optionFound = True
-          break
-      if not optionFound:
-        if ("--help-nupic" in arg):
-          self.printOptions(optionsDesc)
-          sys.exit()
-
-    # Check if no option was passed, i.e. if "setup.py" is the only option
-    # If True, "develop" is passed by default. This is useful when a developer
-    # wishes to build the project directly from an IDE.
-    if len(sys.argv) == 1:
-      print "No command passed. Using 'develop' as default command. Use " \
-            "'python setup.py --help' for more information."
-      sys.argv.append("develop")
-
-    return optionsValues
+  print "Options:\n"
+  for option in optionsDesc:
+    optionUsage = "--" + option[0]
+    if option[1] != "":
+      optionUsage += "=[" + option[1] + "]"
+    optionDesc = option[2]
+    print "    " + optionUsage.ljust(30) + " = " + optionDesc
 
 
 
-  def getCommandLineOption(self, name):
-    if name in self.options:
-      return self.options[name]
+def getCommandLineOptions():
 
+  # optionDesc = [name, value, description]
+  optionsDesc = []
+  optionsDesc.append(
+    ["nupic-core-dir",
+     "dir",
+     "(optional) Absolute path to nupic.core binary release directory"]
+  )
+  optionsDesc.append(
+    ["skip-compare-versions",
+     "",
+     "(optional) Skip nupic.core version comparison"]
+  )
+  optionsDesc.append(
+    ["user-make-command",
+     "file",
+     "(optional) Default `make` command used to build nupic.core"]
+  )
 
-
-  def printOptions(self, optionsDesc):
-    """
-    Print command line options.
-    """
-
-    print "Options:\n"
+  # Read command line options looking for extra options
+  # For example, an user could type:
+  #   python setup.py install --user-make-command="usr/bin/make"
+  # which will set the Make executable
+  optionsValues = dict()
+  for arg in sys.argv[:]:
+    optionFound = False
     for option in optionsDesc:
-      optionUsage = "--" + option[0]
-      if option[1] != "":
-        optionUsage += "=[" + option[1] + "]"
-      optionDesc = option[2]
-      print "    " + optionUsage.ljust(30) + " = " + optionDesc
-
-
-
-  def getPlatformInfo(self):
-    """
-    Identify platform
-    """
-
-    if "linux" in sys.platform:
-      platform = "linux"
-    elif "darwin" in sys.platform:
-      platform = "darwin"
-    elif "win" in sys.platform:
-      platform = "win"
-    else:
-      raise Exception("Platform '%s' is unsupported!" % sys.platform)
-
-    if sys.maxsize > 2**32:
-      bitness = "64"
-    else:
-      bitness = "32"
-
-    return platform, bitness
-
-
-
-  def getVersion(self):
-    """
-    Get version from local file.
-    """
-    with open("VERSION", "r") as versionFile:
-      return versionFile.read().strip()
-
-
-
-  def findRequirements(self):
-    """
-    Read the requirements.txt file and parse into requirements for setup's
-    install_requirements option.
-    """
-    requirementsPath = os.path.join(
-      self.repositoryDir, "external/common/requirements.txt"
-    )
-    return [
-      line.strip()
-      for line in open(requirementsPath).readlines()
-      if not line.startswith("#")
-    ]
-
-
-
-  def generateSwigWrap(self, swigExecutable, swigFlags, interfaceFile):
-    """
-    Generate a swig wrap c++ file from a interface file.
-    """
-    wrap = interfaceFile.replace(".i", "_wrap.cxx")
-
-    cmd = swigExecutable + " -c++ -python "
-    for flag in swigFlags:
-      cmd += flag + " "
-    cmd += interfaceFile
-    print cmd
-    proc = subprocess.Popen(cmd, shell=True)
-    result = proc.wait()
-
-    return wrap
-
-
-
-  def getExtensionModules(self, nupicCoreReleaseDir):
-
-    #
-    # Gives the version of Python necessary to get installation directories
-    # for use with pythonVersion, etc.
-    #
-    if sys.version_info < (2, 7):
-      raise Exception("Fatal Error: Python 2.7 or later is required.")
-
-    pythonVersion = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
-
-    #
-    # Find out where system installation of python is.
-    #
-    pythonPrefix = sys.prefix
-    pythonPrefix = pythonPrefix.replace("\\", "/")
-    pythonIncludeDir = pythonPrefix + "/include/python" + pythonVersion
-
-    #
-    # Finds out version of Numpy and headers' path.
-    #
-    numpyIncludeDir = numpy.get_include()
-    numpyIncludeDir = numpyIncludeDir.replace("\\", "/")
-
-    commonDefines = [
-      ("NUPIC2", None),
-      ("NTA_PLATFORM_" + self.platform + self.bitness, None),
-      ("NTA_PYTHON_SUPPORT", pythonVersion),
-      ("NTA_INTERNAL", None),
-      ("NTA_ASSERTIONS_ON", None),
-      ("NTA_ASM", None),
-      ("HAVE_CONFIG_H", None),
-      ("BOOST_NO_WREGEX", None)]
-
-    commonIncludeDirs = [
-      self.repositoryDir + "/external/" +
-        self.platform + self.bitness + "/include",
-      self.repositoryDir + "/external/common/include",
-      self.repositoryDir + "/extensions",
-      self.repositoryDir,
-      nupicCoreReleaseDir + "/include",
-      pythonIncludeDir,
-      numpyIncludeDir]
-
-    commonCompileFlags = [
-      # Adhere to c++11 spec
-      "-std=c++11",
-      # Generate 32 or 64 bit code
-      "-m" + self.bitness,
-      # `position independent code`, required for shared libraries
-      "-fPIC",
-      "-fvisibility=hidden",
-      "-Wall",
-      "-Wreturn-type",
-      "-Wunused",
-      "-Wno-unused-parameter"]
-    if self.platform == "darwin":
-      commonCompileFlags.append("-stdlib=libc++")
-
-    commonLinkFlags = [
-      "-m" + self.bitness,
-      "-fPIC",
-      "-L" + pythonPrefix + "/lib"]
-
-    commonLibraries = [
-      "dl",
-      "python" + pythonVersion]
-    if self.platform == "linux":
-      commonLibraries.extend(["pthread"])
-
-    commonObjects = [
-      nupicCoreReleaseDir + "/lib/" +
-        self.getLibPrefix() + "nupic_core" + self.getStaticLibExtension()]
-
-    pythonSupportSources = [
-      "extensions/py_support/NumpyVector.cpp",
-      "extensions/py_support/PyArray.cpp",
-      "extensions/py_support/PyHelpers.cpp",
-      "extensions/py_support/PythonStream.cpp"]
-
-    extensions = []
-
-    # This meant to fake out wheel to produce platform-specific .whl files.
-    # Without this, wheel assumes the binary file will be platform-independent,
-    # and we don't want that.
-    fakeExtension = setuptools.Extension(
-      "fake-extension",
-      swig_opts=[],
-      extra_compile_args=[],
-      define_macros=[],
-      extra_link_args=[],
-      include_dirs=[],
-      libraries=[],
-      sources=[],
-      extra_objects=[]
-    )
-    extensions.append(fakeExtension)
-
-    libDynamicCppRegion = setuptools.Extension(
-      "nupic." + self.getLibPrefix() + "cpp_region",
-      extra_compile_args=commonCompileFlags,
-      define_macros=commonDefines,
-      extra_link_args=commonLinkFlags,
-      include_dirs=commonIncludeDirs,
-      libraries=commonLibraries,
-      sources=pythonSupportSources +
-        ["extensions/cpp_region/PyRegion.cpp",
-        "extensions/cpp_region/unittests/PyHelpersTest.cpp"],
-      extra_objects=commonObjects)
-    extensions.append(libDynamicCppRegion)
-
-    #
-    # SWIG
-    #
-    swigDir = self.repositoryDir + "/external/common/share/swig/3.0.2"
-    swigExecutable = self.repositoryDir + "/external/" + self.platform \
-                     + self.bitness + "/bin/swig"
-
-    # SWIG options from: https://github.com/swig/swig/blob/master/Source/Modules/python.cxx#L111
-    swigFlags = [
-      "-features",
-      "autodoc=0,directors=0",
-      "-noproxyimport",
-      "-keyword",
-      "-modern",
-      "-modernargs",
-      "-noproxydel",
-      "-fvirtual",
-      "-fastunpack",
-      "-nofastproxy",
-      "-fastquery",
-      "-outputtuple",
-      "-castmode",
-      "-nosafecstrings",
-      "-w402", #TODO silence warnings
-      "-w503",
-      "-w511",
-      "-w302",
-      "-w362",
-      "-w312",
-      "-w389",
-      "-DSWIG_PYTHON_LEGACY_BOOL",
-      "-I" + swigDir + "/python",
-      "-I" + swigDir]
-    for define in commonDefines:
-      item = "-D" + define[0]
-      if define[1]:
-        item += define[0] + "=" + define[1]
-      swigFlags.append(item)
-    for dir in commonIncludeDirs:
-      item = "-I" + dir
-      swigFlags.append(item)
-
-    wrapAlgorithms = self.generateSwigWrap(swigExecutable, swigFlags,
-                                           "nupic/bindings/algorithms.i")
-    libModuleAlgorithms = setuptools.Extension(
-      "nupic.bindings._algorithms",
-      extra_compile_args=commonCompileFlags,
-      define_macros=commonDefines,
-      extra_link_args=commonLinkFlags,
-      include_dirs=commonIncludeDirs,
-      libraries=commonLibraries,
-      sources=pythonSupportSources +
-        [wrapAlgorithms],
-      extra_objects=commonObjects)
-    extensions.append(libModuleAlgorithms)
-
-    wrapEngineInternal = self.generateSwigWrap(swigExecutable, swigFlags,
-                                               "nupic/bindings/engine_internal.i")
-    libModuleEngineInternal = setuptools.Extension(
-      "nupic.bindings._engine_internal",
-      extra_compile_args=commonCompileFlags,
-      define_macros=commonDefines,
-      extra_link_args=commonLinkFlags,
-      include_dirs=commonIncludeDirs,
-      libraries=commonLibraries,
-      sources=pythonSupportSources +
-        [wrapEngineInternal],
-      extra_objects=commonObjects)
-    extensions.append(libModuleEngineInternal)
-
-    wrapMath = self.generateSwigWrap(swigExecutable, swigFlags,
-                                     "nupic/bindings/math.i")
-    libModuleMath = setuptools.Extension(
-      "nupic.bindings._math",
-      extra_compile_args=commonCompileFlags,
-      define_macros=commonDefines,
-      extra_link_args=commonLinkFlags,
-      include_dirs=commonIncludeDirs,
-      libraries=commonLibraries,
-      sources=pythonSupportSources +
-        [wrapMath,
-        "nupic/bindings/PySparseTensor.cpp"],
-      extra_objects=commonObjects)
-    extensions.append(libModuleMath)
-
-    return extensions
-
-
-
-  def getLibPrefix(self):
-    """
-    Returns the default system prefix of a compiled library.
-    """
-    if self.platform == "linux" or self.platform == "darwin":
-      return "lib"
-    elif self.platform == "win":
-      return ""
-
-
-
-  def getStaticLibExtension(self):
-    """
-    Returns the default system extension of a compiled static library.
-    """
-    if self.platform == "linux" or self.platform == "darwin":
-      return ".a"
-    elif self.platform == "win":
-      return ".lib"
-
-
-
-  def getSharedLibExtension(self):
-    """
-    Returns the default system extension of a compiled shared library.
-    """
-    if self.platform == "linux" or self.platform == "darwin":
-      return ".so"
-    elif self.platform == "win":
-      return ".dll"
-
-
-
-  def extractNupicCoreTarget(self):
-    # First, get the nupic.core SHA and remote location from local config.
-    nupicConfig = {}
-    if os.path.exists(self.repositoryDir + "/.nupic_config"):
-      execfile(
-        os.path.join(self.repositoryDir, ".nupic_config"), {}, nupicConfig
-      )
-    elif os.path.exists(os.environ["HOME"] + "/.nupic_config"):
-      execfile(
-        os.path.join(os.environ["HOME"], ".nupic_config"), {}, nupicConfig
-      )
-    else:
-      execfile(
-        os.path.join(self.repositoryDir, ".nupic_modules"), {}, nupicConfig
-      )
-    return nupicConfig["NUPIC_CORE_REMOTE"], nupicConfig["NUPIC_CORE_COMMITISH"]
-
-
-
-  def getDefaultNupicCoreDirectories(self):
-    # Default nupic.core location is relative to the NuPIC checkout.
-    return self.repositoryDir + "/extensions/core/build/release", \
-           self.repositoryDir + "/extensions/core"
-
-
-
-  def prepareNupicCore(self):
-
-    nupicCoreReleaseDir = self.getCommandLineOption("nupic-core-dir")
-    nupicCoreSourceDir = None
-    fetchNupicCore = True
-
-    if nupicCoreReleaseDir:
-      # User specified that they have their own nupic.core
-      fetchNupicCore = False
-    else:
-      nupicCoreReleaseDir, nupicCoreSourceDir = \
-        self.getDefaultNupicCoreDirectories()
-
-    nupicCoreRemote, nupicCoreCommitish = self.extractNupicCoreTarget()
-
-    if fetchNupicCore:
-      # User has not specified 'nupic.core' location, so we'll download the
-      # binaries.
-
-      nupicCoreRemoteUrl = (nupicCoreBucketURL + "/nupic_core-"
-                            + nupicCoreCommitish + "-" + self.platform
-                            + self.bitness + ".tar.gz")
-      nupicCoreLocalPackage = (nupicCoreSourceDir + "/nupic_core-"
-                               + nupicCoreCommitish + "-" + self.platform
-                               + self.bitness + ".tar.gz")
-      nupicCoreLocalDirToUnpack = ("nupic_core-"
-                                   + nupicCoreCommitish + "-" + self.platform
-                                   + self.bitness)
-
-      if os.path.exists(nupicCoreLocalPackage):
-        print ("Target nupic.core package already exists at "
-               + nupicCoreLocalPackage + ".")
-        self.unpackFile(
-          nupicCoreLocalPackage, nupicCoreLocalDirToUnpack, nupicCoreReleaseDir
-        )
-      else:
-        print "Attempting to fetch nupic.core binaries..."
-        downloadSuccess = self.downloadFile(
-          nupicCoreRemoteUrl, nupicCoreLocalPackage
-        )
-
-        # TODO: Give user a way to clean up all the downloaded binaries. It can
-        # be manually done with `rm -rf $NUPIC_CORE/extensions/core` but would
-        # be cleaner with something like `python setup.py clean`.
-
-        if not downloadSuccess:
-          raise Exception("Failed to download nupic.core tarball from %s}! "
-                          "Ensure you have an internet connection and that the "
-                          "remote tarball exists." % nupicCoreRemoteUrl)
-        else:
-          print "Download successful."
-          self.unpackFile(nupicCoreLocalPackage,
-                          nupicCoreLocalDirToUnpack,
-                          nupicCoreReleaseDir)
-
-    else:
-      print "Using nupic.core binaries at " + nupicCoreReleaseDir
-
-    if self.getCommandLineOption("skip-compare-versions"):
-      skipCompareVersions = True
-    else:
-      skipCompareVersions = not fetchNupicCore
-
-    if not skipCompareVersions:
-      # Compare expected version of nupic.core against installed version
-      file = open(nupicCoreReleaseDir + "/include/nupic/Version.hpp", "r")
-      content = file.read()
-      file.close()
-      nupicCoreVersionFound = re.search(
-        "#define NUPIC_CORE_VERSION \"([a-z0-9]+)\"", content
-      ).group(1)
-
-      if nupicCoreCommitish != nupicCoreVersionFound:
-        raise Exception(
-          "Fatal Error: Unexpected version of nupic.core! "
-          "Expected %s, but detected %s."
-          % (nupicCoreCommitish, nupicCoreVersionFound)
-        )
-
-    return nupicCoreReleaseDir
-
-
-
-  def downloadFile(self, url, destFile, silent=False):
-    """
-    Download a file to the specified location
-    """
-
-    if not silent:
-      print "Downloading from\n\t%s\nto\t%s.\n" % (url, destFile);
-
-    destDir = os.path.dirname(destFile)
-    if not os.path.exists(destDir):
-      os.makedirs(destDir)
-
-    try:
-      response = urllib2.urlopen(url)
-    except urllib2.URLError:
-      return False
-
-    file = open(destFile, "wb")
-
-    totalSize = response.info().getheader('Content-Length').strip()
-    totalSize = int(totalSize)
-    bytesSoFar = 0
-
-    # Download chunks writing them to target file
-    chunkSize = 8192
-    oldPercent = 0
-    while True:
-      chunk = response.read(chunkSize)
-      bytesSoFar += len(chunk)
-
-      if not chunk:
+      name = option[0]
+      if "--" + name in arg:
+        value = None
+        hasValue = (option[1] != "")
+        if hasValue:
+          (_, _, value) = arg.partition("=")
+
+        optionsValues[name] = value
+        sys.argv.remove(arg)
+        optionFound = True
         break
+    if not optionFound:
+      if ("--help-nupic" in arg):
+        printOptions(optionsDesc)
+        sys.exit()
 
-      file.write(chunk)
+  # Check if no option was passed, i.e. if "setup.py" is the only option
+  # If True, "develop" is passed by default. This is useful when a developer
+  # wishes to build the project directly from an IDE.
+  if len(sys.argv) == 1:
+    print "No command passed. Using 'develop' as default command. Use " \
+          "'python setup.py --help' for more information."
+    sys.argv.append("develop")
 
-      # Show progress
-      if not silent:
-        percent = (float(bytesSoFar) / totalSize) * 100
-        percent = int(percent)
-        if percent != oldPercent and percent % 5 == 0:
-          print ("Downloaded %i of %i bytes (%i%%)."
-                 % (bytesSoFar, totalSize, int(percent)))
-          oldPercent = percent
-
-    file.close()
-
-    return True
-
-
-
-  def unpackFile(self, package, dirToUnpack, destDir, silent=False):
-    """
-    Unpack package file to the specified directory
-    """
-
-    if not silent:
-      print "Unpacking %s into %s..." % (package, destDir)
-
-    file = tarfile.open(package, 'r:gz')
-    file.extractall(destDir)
-    file.close()
-
-    # Copy subdirectories to a level up
-    subDirs = os.listdir(destDir + "/" + dirToUnpack)
-    for dir in subDirs:
-      shutil.rmtree(destDir + "/" + dir, True)
-      shutil.move(destDir + "/" + dirToUnpack + "/" + dir, destDir + "/" + dir)
-    shutil.rmtree(destDir + "/" + dirToUnpack, True)
+  return optionsValues
 
 
 
-  def setup(self):
-    # Build and setup NuPIC
-    os.chdir(self.repositoryDir)
-    nupicCoreReleaseDir = self.prepareNupicCore()
-    extensions = self.getExtensionModules(nupicCoreReleaseDir)
-    dist = setuptools.setup(
-      name="nupic",
-      version=self.getVersion(),
-      install_requires=self.findRequirements(),
-      packages=setuptools.find_packages(),
-      # A lot of this stuff may not be packaged properly, most of it was added
-      # in an effort to get a binary package prepared for nupic.regression
-      # testing on Travis-CI, but it wasn't done the right way. I'll be
-      # refactoring a lot of this for
-      # https://github.com/numenta/nupic/issues/408, so this will be changing
-      # soon. -- Matt
-      package_data={
-        "nupic.support": ["nupic-default.xml",
-                          "nupic-logging.conf"],
-        "nupic": ["README.md", "LICENSE.txt"],
-        "nupic.data": ["*.json"],
-        "nupic.frameworks.opf.exp_generator": ["*.json", "*.tpl"],
-        "nupic.frameworks.opf.jsonschema": ["*.json"],
-        "nupic.swarming.jsonschema": ["*.json"]
-      },
-      include_package_data=True,
-      ext_modules=extensions,
-      description="Numenta Platform for Intelligent Computing",
-      author="Numenta",
-      author_email="help@numenta.org",
-      url="https://github.com/numenta/nupic",
-      classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX :: Linux",
-        # It has to be "5 - Production/Stable" or else pypi rejects it!
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence"
-      ],
-      long_description = """\
-Numenta Platform for Intelligent Computing: a machine intelligence platform that implements the HTM learning algorithms. HTM is a detailed computational theory of the neocortex. At the core of HTM are time-based continuous learning algorithms that store and recall spatial and temporal patterns. NuPIC is suited to a variety of problems, particularly anomaly detection and prediction of streaming data sources.
+def getPlatformInfo():
+  """
+  Identify platform
+  """
 
-For more information, see http://numenta.org or the NuPIC wiki at https://github.com/numenta/nupic/wiki.
-""")
+  if "linux" in sys.platform:
+    platform = "linux"
+  elif "darwin" in sys.platform:
+    platform = "darwin"
+  elif "win" in sys.platform:
+    platform = "win"
+  else:
+    raise Exception("Platform '%s' is unsupported!" % sys.platform)
 
-    # Copy proto files located at nupic.core dir into nupic dir
-    buildDir = glob.glob(self.repositoryDir + "/build/lib.*/")[0]
-    protoBuildDir = nupicCoreReleaseDir + "/include/nupic/proto"
-    protoSourceDir = buildDir + "/nupic/bindings/proto"
-    if not os.path.exists(protoSourceDir):
-      os.makedirs(protoSourceDir)
-    for file in glob.glob(protoBuildDir + "/*.capnp"):
-      shutil.copy(file, protoSourceDir)
+  if sys.maxsize > 2**32:
+    bitness = "64"
+  else:
+    bitness = "32"
 
-    # Copy binaries located at nupic.core dir into source dir
-    print "Copying binaries from " + nupicCoreReleaseDir + "/bin" + " to " \
-          + self.repositoryDir + "/bin..."
-    if not os.path.exists(self.repositoryDir + "/bin"):
-      os.makedirs(self.repositoryDir + "/bin")
-    shutil.copy(
-      nupicCoreReleaseDir + "/bin/py_region_test", self.repositoryDir + "/bin"
+  return platform, bitness
+
+
+
+def getVersion():
+  """
+  Get version from local file.
+  """
+  with open("VERSION", "r") as versionFile:
+    return versionFile.read().strip()
+
+
+
+def generateSwigWrap(swigExecutable, swigFlags, interfaceFile):
+  """
+  Generate a swig wrap c++ file from a interface file.
+  """
+  wrap = interfaceFile.replace(".i", "_wrap.cxx")
+
+  cmd = swigExecutable + " -c++ -python "
+  for flag in swigFlags:
+    cmd += flag + " "
+  cmd += interfaceFile
+  print cmd
+  proc = subprocess.Popen(cmd, shell=True)
+  proc.wait()
+
+  return wrap
+
+
+
+def findRequirements():
+  """
+  Read the requirements.txt file and parse into requirements for setup's
+  install_requirements option.
+  """
+  requirementsPath = os.path.join(
+    REPO_DIR, "external/common/requirements.txt"
+  )
+  return [
+    line.strip()
+    for line in open(requirementsPath).readlines()
+    if not line.startswith("#")
+  ]
+
+
+
+def getLibPrefix(platform):
+  """
+  Returns the default system prefix of a compiled library.
+  """
+  if platform in UNIX_PLATFORMS:
+    return "lib"
+  elif platform in WINDOWS_PLATFORMS:
+    return ""
+
+
+
+def getStaticLibExtension(platform):
+  """
+  Returns the default system extension of a compiled static library.
+  """
+  if platform in UNIX_PLATFORMS:
+    return ".a"
+  elif platform in WINDOWS_PLATFORMS:
+    return ".lib"
+
+
+
+def getSharedLibExtension(platform):
+  """
+  Returns the default system extension of a compiled shared library.
+  """
+  if platform in UNIX_PLATFORMS:
+    return ".so"
+  elif platform in WINDOWS_PLATFORMS:
+    return ".dll"
+
+
+
+
+def extractNupicCoreTarget():
+  # First, get the nupic.core SHA and remote location from local config.
+  nupicConfig = {}
+  if os.path.exists(REPO_DIR + "/.nupic_config"):
+    execfile(
+      os.path.join(REPO_DIR, ".nupic_config"), {}, nupicConfig
     )
+  elif os.path.exists(os.environ["HOME"] + "/.nupic_config"):
+    execfile(
+      os.path.join(os.environ["HOME"], ".nupic_config"), {}, nupicConfig
+    )
+  else:
+    execfile(
+      os.path.join(REPO_DIR, ".nupic_modules"), {}, nupicConfig
+    )
+  return nupicConfig["NUPIC_CORE_REMOTE"], nupicConfig["NUPIC_CORE_COMMITISH"]
 
-    # Copy cpp_region located at build dir into source dir
-    shutil.copy(buildDir + "/nupic/" + self.getLibPrefix() + "cpp_region" +
-                self.getSharedLibExtension(), self.repositoryDir + "/nupic")
+
+
+def getDefaultNupicCoreDirectories():
+  # Default nupic.core location is relative to the NuPIC checkout.
+  return REPO_DIR + "/extensions/core/build/release", \
+         REPO_DIR + "/extensions/core"
 
 
 
-if __name__ == '__main__':
-  Setup().setup()
+def getExtensionModules(nupicCoreReleaseDir, platform, bitness):
+  #
+  # Gives the version of Python necessary to get installation directories
+  # for use with pythonVersion, etc.
+  #
+  if sys.version_info < (2, 7):
+    raise Exception("Fatal Error: Python 2.7 or later is required.")
+
+  pythonVersion = str(sys.version_info[0]) + '.' + str(sys.version_info[1])
+
+  #
+  # Find out where system installation of python is.
+  #
+  pythonPrefix = sys.prefix
+  pythonPrefix = pythonPrefix.replace("\\", "/")
+  pythonIncludeDir = pythonPrefix + "/include/python" + pythonVersion
+
+  #
+  # Finds out version of Numpy and headers' path.
+  #
+  numpyIncludeDir = numpy.get_include()
+  numpyIncludeDir = numpyIncludeDir.replace("\\", "/")
+
+  commonDefines = [
+    ("NUPIC2", None),
+    ("NTA_PLATFORM_" + platform + bitness, None),
+    ("NTA_PYTHON_SUPPORT", pythonVersion),
+    ("NTA_INTERNAL", None),
+    ("NTA_ASSERTIONS_ON", None),
+    ("NTA_ASM", None),
+    ("HAVE_CONFIG_H", None),
+    ("BOOST_NO_WREGEX", None)]
+
+  commonIncludeDirs = [
+    REPO_DIR + "/external/" + platform + bitness + "/include",
+    REPO_DIR + "/external/common/include",
+    REPO_DIR + "/extensions",
+    REPO_DIR,
+    nupicCoreReleaseDir + "/include",
+    pythonIncludeDir,
+    numpyIncludeDir]
+
+  commonCompileFlags = [
+    # Adhere to c++11 spec
+    "-std=c++11",
+    # Generate 32 or 64 bit code
+    "-m" + bitness,
+    # `position independent code`, required for shared libraries
+    "-fPIC",
+    "-fvisibility=hidden",
+    "-Wall",
+    "-Wreturn-type",
+    "-Wunused",
+    "-Wno-unused-parameter"]
+  if platform == "darwin":
+    commonCompileFlags.append("-stdlib=libc++")
+
+  commonLinkFlags = [
+    "-m" + bitness,
+    "-fPIC",
+    "-L" + pythonPrefix + "/lib"]
+
+  commonLibraries = [
+    "dl",
+    "python" + pythonVersion]
+  if platform == "linux":
+    commonLibraries.extend(["pthread"])
+
+  commonObjects = [
+    nupicCoreReleaseDir + "/lib/" +
+      getLibPrefix(platform) + "nupic_core" + getStaticLibExtension(platform)]
+
+  pythonSupportSources = [
+    "extensions/py_support/NumpyVector.cpp",
+    "extensions/py_support/PyArray.cpp",
+    "extensions/py_support/PyHelpers.cpp",
+    "extensions/py_support/PythonStream.cpp"]
+
+  extensions = []
+
+  # This meant to fake out wheel to produce platform-specific .whl files.
+  # Without this, wheel assumes the binary file will be platform-independent,
+  # and we don't want that.
+  fakeExtension = Extension(
+    "fake-extension",
+    swig_opts=[],
+    extra_compile_args=[],
+    define_macros=[],
+    extra_link_args=[],
+    include_dirs=[],
+    libraries=[],
+    sources=[],
+    extra_objects=[]
+  )
+  extensions.append(fakeExtension)
+
+  libDynamicCppRegion = Extension(
+    "nupic." + getLibPrefix(platform) + "cpp_region",
+    extra_compile_args=commonCompileFlags,
+    define_macros=commonDefines,
+    extra_link_args=commonLinkFlags,
+    include_dirs=commonIncludeDirs,
+    libraries=commonLibraries,
+    sources=pythonSupportSources +
+      ["extensions/cpp_region/PyRegion.cpp",
+      "extensions/cpp_region/unittests/PyHelpersTest.cpp"],
+    extra_objects=commonObjects)
+  extensions.append(libDynamicCppRegion)
+
+  #
+  # SWIG
+  #
+  swigDir = REPO_DIR + "/external/common/share/swig/3.0.2"
+  swigExecutable = REPO_DIR + "/external/" + platform \
+                   + bitness + "/bin/swig"
+
+  # SWIG options from:
+  # https://github.com/swig/swig/blob/master/Source/Modules/python.cxx#L111
+  swigFlags = [
+    "-features",
+    "autodoc=0,directors=0",
+    "-noproxyimport",
+    "-keyword",
+    "-modern",
+    "-modernargs",
+    "-noproxydel",
+    "-fvirtual",
+    "-fastunpack",
+    "-nofastproxy",
+    "-fastquery",
+    "-outputtuple",
+    "-castmode",
+    "-nosafecstrings",
+    "-w402", #TODO silence warnings
+    "-w503",
+    "-w511",
+    "-w302",
+    "-w362",
+    "-w312",
+    "-w389",
+    "-DSWIG_PYTHON_LEGACY_BOOL",
+    "-I" + swigDir + "/python",
+    "-I" + swigDir]
+  for define in commonDefines:
+    item = "-D" + define[0]
+    if define[1]:
+      item += define[0] + "=" + define[1]
+    swigFlags.append(item)
+  for dir in commonIncludeDirs:
+    item = "-I" + dir
+    swigFlags.append(item)
+
+  wrapAlgorithms = generateSwigWrap(swigExecutable, swigFlags,
+                                         "nupic/bindings/algorithms.i")
+  libModuleAlgorithms = Extension(
+    "nupic.bindings._algorithms",
+    extra_compile_args=commonCompileFlags,
+    define_macros=commonDefines,
+    extra_link_args=commonLinkFlags,
+    include_dirs=commonIncludeDirs,
+    libraries=commonLibraries,
+    sources=pythonSupportSources +
+      [wrapAlgorithms],
+    extra_objects=commonObjects)
+  extensions.append(libModuleAlgorithms)
+
+  wrapEngineInternal = generateSwigWrap(swigExecutable, swigFlags,
+                                             "nupic/bindings/engine_internal.i")
+  libModuleEngineInternal = Extension(
+    "nupic.bindings._engine_internal",
+    extra_compile_args=commonCompileFlags,
+    define_macros=commonDefines,
+    extra_link_args=commonLinkFlags,
+    include_dirs=commonIncludeDirs,
+    libraries=commonLibraries,
+    sources=pythonSupportSources +
+      [wrapEngineInternal],
+    extra_objects=commonObjects)
+  extensions.append(libModuleEngineInternal)
+
+  wrapMath = generateSwigWrap(swigExecutable, swigFlags,
+                                   "nupic/bindings/math.i")
+  libModuleMath = Extension(
+    "nupic.bindings._math",
+    extra_compile_args=commonCompileFlags,
+    define_macros=commonDefines,
+    extra_link_args=commonLinkFlags,
+    include_dirs=commonIncludeDirs,
+    libraries=commonLibraries,
+    sources=pythonSupportSources +
+      [wrapMath,
+      "nupic/bindings/PySparseTensor.cpp"],
+    extra_objects=commonObjects)
+  extensions.append(libModuleMath)
+
+  return extensions
+
+
+
+def getCommandLineOption(name, options):
+  if name in options:
+    return options[name]
+
+
+
+def prepareNupicCore(options, platform, bitness):
+
+  nupicCoreReleaseDir = getCommandLineOption("nupic-core-dir", options)
+  nupicCoreSourceDir = None
+  fetchNupicCore = True
+
+  if nupicCoreReleaseDir:
+    # User specified that they have their own nupic.core
+    fetchNupicCore = False
+  else:
+    nupicCoreReleaseDir, nupicCoreSourceDir = \
+      getDefaultNupicCoreDirectories()
+
+  nupicCoreRemote, nupicCoreCommitish = extractNupicCoreTarget()
+
+  if fetchNupicCore:
+    # User has not specified 'nupic.core' location, so we'll download the
+    # binaries.
+
+    nupicCoreRemoteUrl = (NUPIC_CORE_BUCKET + "/nupic_core-"
+                          + nupicCoreCommitish + "-" + platform
+                          + bitness + ".tar.gz")
+    nupicCoreLocalPackage = (nupicCoreSourceDir + "/nupic_core-"
+                             + nupicCoreCommitish + "-" + platform
+                             + bitness + ".tar.gz")
+    nupicCoreLocalDirToUnpack = ("nupic_core-"
+                                 + nupicCoreCommitish + "-" + platform
+                                 + bitness)
+
+    if os.path.exists(nupicCoreLocalPackage):
+      print ("Target nupic.core package already exists at "
+             + nupicCoreLocalPackage + ".")
+      unpackFile(
+        nupicCoreLocalPackage, nupicCoreLocalDirToUnpack, nupicCoreReleaseDir
+      )
+    else:
+      print "Attempting to fetch nupic.core binaries..."
+      downloadSuccess = downloadFile(
+        nupicCoreRemoteUrl, nupicCoreLocalPackage
+      )
+
+      # TODO: Give user a way to clean up all the downloaded binaries. It can
+      # be manually done with `rm -rf $NUPIC_CORE/extensions/core` but would
+      # be cleaner with something like `python setup.py clean`.
+
+      if not downloadSuccess:
+        raise Exception("Failed to download nupic.core tarball from %s}! "
+                        "Ensure you have an internet connection and that the "
+                        "remote tarball exists." % nupicCoreRemoteUrl)
+      else:
+        print "Download successful."
+        unpackFile(nupicCoreLocalPackage,
+                        nupicCoreLocalDirToUnpack,
+                        nupicCoreReleaseDir)
+
+  else:
+    print "Using nupic.core binaries at " + nupicCoreReleaseDir
+
+  if getCommandLineOption("skip-compare-versions", options):
+    skipCompareVersions = True
+  else:
+    skipCompareVersions = not fetchNupicCore
+
+  if not skipCompareVersions:
+    # Compare expected version of nupic.core against installed version
+    file = open(nupicCoreReleaseDir + "/include/nupic/Version.hpp", "r")
+    content = file.read()
+    file.close()
+    nupicCoreVersionFound = re.search(
+      "#define NUPIC_CORE_VERSION \"([a-z0-9]+)\"", content
+    ).group(1)
+
+    if nupicCoreCommitish != nupicCoreVersionFound:
+      raise Exception(
+        "Fatal Error: Unexpected version of nupic.core! "
+        "Expected %s, but detected %s."
+        % (nupicCoreCommitish, nupicCoreVersionFound)
+      )
+
+  return nupicCoreReleaseDir
+
+
+
+def postProcess():
+  # Copy proto files located at nupic.core dir into nupic dir
+  buildDir = glob.glob(REPO_DIR + "/build/lib.*/")[0]
+  protoBuildDir = nupicCoreReleaseDir + "/include/nupic/proto"
+  protoSourceDir = buildDir + "/nupic/bindings/proto"
+  if not os.path.exists(protoSourceDir):
+    os.makedirs(protoSourceDir)
+  for file in glob.glob(protoBuildDir + "/*.capnp"):
+    shutil.copy(file, protoSourceDir)
+
+  # Copy binaries located at nupic.core dir into source dir
+  print "Copying binaries from " + nupicCoreReleaseDir + "/bin" + " to " \
+        + REPO_DIR + "/bin..."
+  if not os.path.exists(REPO_DIR + "/bin"):
+    os.makedirs(REPO_DIR + "/bin")
+  shutil.copy(
+    nupicCoreReleaseDir + "/bin/py_region_test", REPO_DIR + "/bin"
+  )
+  # Copy cpp_region located at build dir into source dir
+  shutil.copy(buildDir + "/nupic/" + getLibPrefix(platform) + "cpp_region" +
+              getSharedLibExtension(platform), REPO_DIR + "/nupic")
+
+
+
+
+options = getCommandLineOptions()
+platform, bitness = getPlatformInfo()
+
+# Build and setup NuPIC
+cwd = os.getcwd()
+os.chdir(REPO_DIR)
+
+try:
+  nupicCoreReleaseDir = prepareNupicCore(options, platform, bitness)
+  extensions = getExtensionModules(
+    nupicCoreReleaseDir, platform, bitness
+  )
+
+  setup(
+    name="nupic",
+    version=getVersion(),
+    install_requires=findRequirements(),
+    packages=find_packages(),
+    # A lot of this stuff may not be packaged properly, most of it was added
+    # in an effort to get a binary package prepared for nupic.regression
+    # testing on Travis-CI, but it wasn't done the right way. I'll be
+    # refactoring a lot of this for
+    # https://github.com/numenta/nupic/issues/408, so this will be changing
+    # soon. -- Matt
+    package_data={
+      "nupic.support": ["nupic-default.xml",
+                        "nupic-logging.conf"],
+      "nupic": ["README.md", "LICENSE.txt"],
+      "nupic.data": ["*.json"],
+      "nupic.frameworks.opf.exp_generator": ["*.json", "*.tpl"],
+      "nupic.frameworks.opf.jsonschema": ["*.json"],
+      "nupic.swarming.jsonschema": ["*.json"]
+    },
+    include_package_data=True,
+    ext_modules=extensions,
+    description="Numenta Platform for Intelligent Computing",
+    author="Numenta",
+    author_email="help@numenta.org",
+    url="https://github.com/numenta/nupic",
+    classifiers=[
+      "Programming Language :: Python",
+      "Programming Language :: Python :: 2",
+      "License :: OSI Approved :: GNU General Public License (GPL)",
+      "Operating System :: MacOS :: MacOS X",
+      "Operating System :: POSIX :: Linux",
+      # It has to be "5 - Production/Stable" or else pypi rejects it!
+      "Development Status :: 5 - Production/Stable",
+      "Environment :: Console",
+      "Intended Audience :: Science/Research",
+      "Topic :: Scientific/Engineering :: Artificial Intelligence"
+    ],
+    long_description = """\
+  Numenta Platform for Intelligent Computing: a machine intelligence platform that implements the HTM learning algorithms. HTM is a detailed computational theory of the neocortex. At the core of HTM are time-based continuous learning algorithms that store and recall spatial and temporal patterns. NuPIC is suited to a variety of problems, particularly anomaly detection and prediction of streaming data sources.
+
+  For more information, see http://numenta.org or the NuPIC wiki at https://github.com/numenta/nupic/wiki.
+  """)
+
+  postProcess()
+finally:
+  os.chdir(cwd)


### PR DESCRIPTION
@david-ragazzi This PR doesn't change any functionality.

Removed the Setup class with simple setup() call. All previous Setup
methods have been extracted into independent functions and "self"
properties used within each method converted into function parameters or
constants.

Also:
- introduced constants
- cleaned up package_data
- allowed execution from outside repo dir

(Hopefully @scottpurdy will like this since he commented about it earlier?)